### PR TITLE
[Fix] DatePickerInput 부분 선택 시 API 호출 버그

### DIFF
--- a/app/(main)/log/[id]/hooks/useDetailData.ts
+++ b/app/(main)/log/[id]/hooks/useDetailData.ts
@@ -8,19 +8,23 @@ interface RequestData {
     url: string
     startDate?: string
     endDate?: string
+    enabled: boolean
 }
 
-export const useDetailData = ({ url, startDate, endDate }: RequestData) => {
+export const useDetailData = ({ url, startDate, endDate, enabled = true }: RequestData) => {
     const params = useMemo(
         () => ({
-            start: startDate || '2024-11-01',
-            end: endDate || '2025-11-01',
+            start: startDate,
+            end: endDate,
         }),
         [startDate, endDate],
     )
+
     const { data, isLoading, error } = useData<DetailResponse>({
         url,
         params,
+        enabled,
     })
+
     return { detailData: data, isLoading, error }
 }

--- a/app/(main)/log/[id]/hooks/useSearchDate.ts
+++ b/app/(main)/log/[id]/hooks/useSearchDate.ts
@@ -3,7 +3,10 @@ import { useState } from 'react'
 import { formatToKSTDate } from '@/lib/utils/date'
 
 export const useSearchDate = () => {
-    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([new Date(), new Date()])
+    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([
+        new Date(new Date().setFullYear(new Date().getFullYear() - 1)),
+        new Date(),
+    ])
 
     const handleDateRangeChange = (value: [Date | null, Date | null]) => {
         setDateRange(value)

--- a/app/(main)/log/[id]/hooks/useSearchDate.ts
+++ b/app/(main)/log/[id]/hooks/useSearchDate.ts
@@ -1,7 +1,9 @@
 import { useState } from 'react'
 
+import { formatToKSTDate } from '@/lib/utils/date'
+
 export const useSearchDate = () => {
-    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([null, null])
+    const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([new Date(), new Date()])
 
     const handleDateRangeChange = (value: [Date | null, Date | null]) => {
         setDateRange(value)
@@ -13,10 +15,17 @@ export const useSearchDate = () => {
         }
 
         return {
-            startDate: dateRange[0].toISOString().split('T')[0],
-            endDate: dateRange[1].toISOString().split('T')[0],
+            startDate: formatToKSTDate(dateRange[0]),
+            endDate: formatToKSTDate(dateRange[1]),
         }
     }
 
-    return { dateRange, handleDateRangeChange, getFormattedDates }
+    const isDateRangeValid = Boolean(dateRange[0] && dateRange[1])
+
+    return {
+        dateRange,
+        handleDateRangeChange,
+        getFormattedDates,
+        isDateRangeValid,
+    }
 }

--- a/app/(main)/log/[id]/page.tsx
+++ b/app/(main)/log/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from 'next/navigation'
 
 import Breadcrumb from '@/components/common/Breadcrumb'
 import ExcelButton from '@/components/common/Button/ExcelButton'
+import LinkButton from '@/components/common/Button/LinkButton'
 import { RoundButton } from '@/components/common/Button/RoundButton'
 import ControlLayout from '@/components/common/ControlLayout'
 import ErrorMessage from '@/components/common/ErrorMessage'
@@ -30,13 +31,15 @@ import { downloadExcel } from './utils/excel'
 const DetailPage = () => {
     const { id } = useParams()
     const router = useRouter()
-    const { dateRange, handleDateRangeChange, getFormattedDates } = useSearchDate()
+    const { dateRange, handleDateRangeChange, getFormattedDates, isDateRangeValid } = useSearchDate()
     const dates = getFormattedDates()
     const { detailData, isLoading, error } = useDetailData({
         url: `${API_ENDPOINTS.LOG}/${id}`,
         startDate: dates?.startDate,
         endDate: dates?.endDate,
+        enabled: isDateRangeValid,
     })
+
     const formattedVehicleNumber = detailData?.vehicleType.vehicleNumber
         ? addSpaceVehicleNumber(detailData.vehicleType.vehicleNumber)
         : ''
@@ -90,7 +93,6 @@ const DetailPage = () => {
     return (
         <div className={styles.container}>
             <Breadcrumb type={'운행일지'} />
-
             <ControlLayout
                 control={
                     <DatePickerInput
@@ -100,6 +102,7 @@ const DetailPage = () => {
                                 <CalendarIcon size={16} stroke={1} />
                             </div>
                         }
+                        maxDate={new Date()}
                         leftSectionPointerEvents='none'
                         type='range'
                         size='lg'
@@ -107,6 +110,8 @@ const DetailPage = () => {
                         placeholder='과세기간 범위 선택'
                         value={dateRange}
                         onChange={handleDateRangeChange}
+                        valueFormat='YYYY-MM-DD'
+                        clearable={true}
                         styles={{
                             input: {
                                 width: '300px',
@@ -123,17 +128,20 @@ const DetailPage = () => {
                     </div>
                 }
                 secondaryButton={
-                    <div className={styles.deleteButtonWrapper}>
-                        <RoundButton color='primary' size='small' onClick={handleDeleteButtonClick}>
-                            <div className={styles.deleteButton}>
-                                <Image src='/icons/white-trash-icon.svg' alt='add' width={18} height={18} />
-                                차량삭제
-                            </div>
-                        </RoundButton>
-                    </div>
+                    true ? (
+                        <div className={styles.deleteButtonWrapper}>
+                            <RoundButton color='primary' size='small' onClick={handleDeleteButtonClick}>
+                                <div className={styles.deleteButton}>
+                                    <Image src='/icons/white-trash-icon.svg' alt='add' width={18} height={18} />
+                                    차량삭제
+                                </div>
+                            </RoundButton>
+                        </div>
+                    ) : (
+                        <></>
+                    )
                 }
             />
-
             <Modal
                 isOpen={isConfirmModalOpen}
                 message={confirmModalMessage as ModalMessageType}
@@ -141,14 +149,12 @@ const DetailPage = () => {
                 onClose={closeConfirmModal}
                 onConfirm={confirmDeleteVehicle}
             />
-
             <Modal
                 isOpen={isAlertModalOpen}
                 message={alertModalMessage as ModalMessageType}
                 variant={{ variant: 'alert', confirmButton: '확인' }}
                 onClose={closeAlertModal}
             />
-
             <div className={styles.tableWrapper}>
                 <table>
                     <tbody>
@@ -284,10 +290,9 @@ const DetailPage = () => {
                 </table>
             </div>
 
-            {/* TODO: LinkButton 다시 적용
             <LinkButton href={`/log/${id}/daily`} className={styles.linkButton}>
                 일별 및 시간별 조회
-            </LinkButton> */}
+            </LinkButton>
         </div>
     )
 }

--- a/components/common/Breadcrumb/constants.ts
+++ b/components/common/Breadcrumb/constants.ts
@@ -1,7 +1,7 @@
 export const logPath = [
     { label: '운행기록', path: '/log' },
-    { label: '운행일지', path: '/log' },
-    { label: '일별 및 시간별 운행기록', path: '/log' },
+    { label: '운행일지', path: '/log/:id' },
+    { label: '일별 및 시간별 운행기록', path: '/log/:id/daily' },
 ] as const
 
 export const noticePath = [

--- a/components/common/Breadcrumb/index.tsx
+++ b/components/common/Breadcrumb/index.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import Link from 'next/link'
+import { useParams } from 'next/navigation'
 
 import * as styles from './styles.css'
 import { breadcrumbPath, BreadcrumbType, logPath } from './types'
@@ -8,16 +11,21 @@ interface BreadcrumbProps {
 }
 
 const Breadcrumb = ({ type }: BreadcrumbProps) => {
+    const { id } = useParams()
     const paths = breadcrumbPath[type as keyof typeof breadcrumbPath] ?? logPath
     const index = paths.findIndex((item) => item.label === type)
     const visibleItems = paths.slice(0, index + 1)
+
+    const replacePath = (path: string) => {
+        return path.replace(':id', id as string)
+    }
 
     return (
         <ul className={styles.list} aria-label='breadcrumb'>
             {visibleItems.map((item, index) => (
                 <li key={item.label} className={styles.item}>
                     <Link
-                        href={item.path}
+                        href={replacePath(item.path)}
                         className={styles.link}
                         aria-current={index === visibleItems.length - 1 ? 'page' : undefined}
                     >

--- a/constants/api.ts
+++ b/constants/api.ts
@@ -2,7 +2,8 @@ export const API_URL = process.env.NEXT_PUBLIC_API_URL
 
 export interface UseDataRequest {
     url: string
-    params?: Record<string, string | number>
+    params?: Record<string, string | number | undefined>
+    enabled?: boolean
 }
 
 export const API_ENDPOINTS = {

--- a/hooks/useData.ts
+++ b/hooks/useData.ts
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react'
 import { UseDataRequest } from '@/constants/api'
 import { httpClient } from '@/lib/apis/client'
 
-export const useData = <T>({ url, params }: UseDataRequest) => {
+export const useData = <T>({ url, params, enabled = true }: UseDataRequest) => {
     const [data, setData] = useState<T>()
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
+        if (!enabled) return
         const getData = async () => {
             try {
                 setIsLoading(true)
@@ -22,7 +23,7 @@ export const useData = <T>({ url, params }: UseDataRequest) => {
             }
         }
         getData()
-    }, [url, params])
+    }, [url, params, enabled])
 
     return { data, isLoading, error }
 }

--- a/lib/apis/interceptors.ts
+++ b/lib/apis/interceptors.ts
@@ -4,6 +4,8 @@ import { API_URL } from '@/constants/api'
 import { httpClient } from '@/lib/apis/client'
 import { useAuthStore } from '@/stores/useAuthStore'
 
+import { authService } from './auth'
+
 interface CustomRequestConfig extends InternalAxiosRequestConfig {
     isRequestAlready?: boolean
 }
@@ -60,6 +62,7 @@ export const setupResponseInterceptor = (instance: AxiosInstance) => {
                     }
                 } catch (retryError) {
                     console.log(retryError)
+                    await authService.postSignOut()
                     logout()
                     window.location.href = '/signin'
                 }

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -7,6 +7,17 @@ export const formatISODateToKorean = (isoDate: string, isIncludeTime = true) => 
     return isIncludeTime ? `${year}년 ${month}월 ${date}일 ${hour}시 ${minute}분` : `${year}년 ${month}월 ${date}일`
 }
 
+// 기존 new Date()는 UTC 기준 -> UTC 시간을 KST로 변환하는 날짜 포맷팅 (UTC+9) / YYYY-MM-DD
+export const formatToKSTDate = (date: Date): string => {
+    const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000)
+
+    const year = kstDate.getUTCFullYear()
+    const month = String(kstDate.getUTCMonth() + 1).padStart(2, '0')
+    const day = String(kstDate.getUTCDate()).padStart(2, '0')
+
+    return `${year}-${month}-${day}`
+}
+
 // { year, month, date, hour, minute } -> 2024-01-15T09:30:00
 export const formatToISODate = ({
     year,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #157
<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

## 📋 작업 내용

### 문제점

> 1. startDate만 선택해도 API 호출이 발생하는 이슈
> 2. 선택한 날짜가 과세기간에 정확히 반영되지 않는 문제

### 원인 및 해결책

1. API 호출 이슈

> - useDetailData 훅에서 API 호출 조건에 enabled 속성 추가
> - startDate와 endDate가 모두 선택되어야만 API가 호출되도록 변경

2. 과세기간 반영 오류

> - UTC 시간을 KST(한국 시간)로 정확하게 변환하는 로직 개선

### 추가 변경사항

DatePickerInput의 기본 날짜 범위를 1년 전 ~ 오늘로 설정

### 근본 원인

- useData에서 랩핑한 useDetailData 커스텀훅이 리렌더링 시 재실행되며 불필요한 API 요청 발생
- tanstack 라이브러리의 enabled 속성과 같은 처리가 커스텀훅에는 없어서 문제 발생

## 🔧 변경 사항

- [x] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 삭제된 파일/코드
- [ ] ⚙️ 설정 파일 (.env, .gitignore 등)

## 📸 스크린샷

![2025-02-063 05 54-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9aa8d093-bbad-4cfa-8e7d-6fbbd17c5c61)