### PR TITLE
[Fix] 경로조회 페이지 Suspense 적용해 프리렌더 에러 문제 해결

### DIFF
--- a/app/(main)/route/components/RouteSearchSection/index.tsx
+++ b/app/(main)/route/components/RouteSearchSection/index.tsx
@@ -2,6 +2,7 @@
 
 import { Loader, Tooltip } from '@mantine/core'
 import { DatePickerInput } from '@mantine/dates'
+// import { useSearchParams } from 'next/navigation'
 import { ChangeEvent, useState } from 'react'
 
 import Accordion from '@/components/common/Accordion'
@@ -47,6 +48,15 @@ const RouteSearchSection = ({ mapRef, onRoutesChange }: RouteSearchSectionProps)
     const [isSearchingVehicle, startSearchingVehicle, finishSearchingVehicle] = useLoading()
     const [isSearchingRoute, startSearchingRoute, finishSearchingRoute] = useLoading()
     const { isModalOpen, message, closeModal, openModalWithMessage } = useModal()
+
+    // const searchParams = useSearchParams()
+
+    // useEffect(() => {
+    //     const vehicleId = searchParams.get('vehicleId')
+    //     const vehicleNumber = searchParams.get('vehicleNumber')
+    //     const startDate = searchParams.get('startDate')
+    //     const endDate = searchParams.get('endDate')
+    // }, [searchParams])
 
     const clearUrlAndRoute = () => {
         clearAllQueries()

--- a/app/(main)/route/page.tsx
+++ b/app/(main)/route/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 
 import MapSection from '@/app/(main)/route/components/MapSection'
 import RouteSearchSection from '@/app/(main)/route/components/RouteSearchSection'
@@ -28,9 +28,11 @@ const RoutePage = () => {
 
     return (
         <div className={styles.container}>
-            <RouteSearchSection mapRef={mapRef} onRoutesChange={setRoutes} />
-            <RouteTimelineSection />
-            <MapSection mapRef={mapRef} mapState={mapState} routes={routes} onLoad={() => setIsMapLoaded(true)} />
+            <Suspense fallback={<div>서스펜스 불러오는 중!</div>}>
+                <RouteSearchSection mapRef={mapRef} onRoutesChange={setRoutes} />
+                <RouteTimelineSection />
+                <MapSection mapRef={mapRef} mapState={mapState} routes={routes} onLoad={() => setIsMapLoaded(true)} />
+            </Suspense>
         </div>
     )
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

## 📋 작업 내용

`useSearchParams` 사용으로 인한 빌드 시 프리렌더 에러가 발생했습니다.
경로조회 페이지 `useSearchParams` 사용 컴포넌트에 Suspense를 사용해 위 문제를 해결했습니다.

